### PR TITLE
Fix #1

### DIFF
--- a/oneliner/expr_transform.py
+++ b/oneliner/expr_transform.py
@@ -1,6 +1,5 @@
 import typing
 from ast import *
-from ast import expr
 
 from oneliner.namespaces import Namespace
 

--- a/oneliner/pending_nodes.py
+++ b/oneliner/pending_nodes.py
@@ -1,6 +1,7 @@
+import sys
 import typing
+import warnings
 from ast import *
-from ast import AST
 
 import oneliner.utils as utils
 from oneliner.expr_transform import expr_transf
@@ -822,6 +823,16 @@ class PendingFunctionDef(_PendingCompoundStmt):
     def __init__(self, node: FunctionDef, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
         self.node = node
+
+        if sys.version_info < (3, 12):
+            # pep 709 removed the namespace of comprehension
+            # no need to check this in py 3.12+
+            if node.name in ["listcomp", "genexpr", "setcomp", "dictcomp"]:
+                warnings.warn(
+                    f"Reserved function name '{node.name}' used, "
+                    "result may be unreliable",
+                    RuntimeWarning,
+                )
 
         for tmp_nsp in self.nsp.inner_nsp:
             if (

--- a/oneliner/pending_nodes.py
+++ b/oneliner/pending_nodes.py
@@ -1,6 +1,4 @@
-import sys
 import typing
-import warnings
 from ast import *
 
 import oneliner.utils as utils
@@ -823,16 +821,6 @@ class PendingFunctionDef(_PendingCompoundStmt):
     def __init__(self, node: FunctionDef, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
         self.node = node
-
-        if sys.version_info < (3, 12):
-            # pep 709 removed the namespace of comprehension
-            # no need to check this in py 3.12+
-            if node.name in ["listcomp", "genexpr", "setcomp", "dictcomp"]:
-                warnings.warn(
-                    f"Reserved function name '{node.name}' used, "
-                    "result may be unreliable",
-                    RuntimeWarning,
-                )
 
         for tmp_nsp in self.nsp.inner_nsp:
             if (

--- a/tests/oneliner_test.py
+++ b/tests/oneliner_test.py
@@ -134,6 +134,14 @@ class TestNonlocal(test_utils.OnelinerTestCaseBase):
     test_case_filename = "nonlocal.py"
 
 
+class TestComprehension(test_utils.OnelinerTestCaseBase):
+    """
+    Test if the namespace of comprehension expr is isolated
+    """
+
+    test_case_filename = "comprehension.py"
+
+
 class TestGlobal(test_utils.OnelinerTestCaseBase):
     test_case_filename = "global.py"
 

--- a/tests/test_cases/comprehension.py
+++ b/tests/test_cases/comprehension.py
@@ -1,0 +1,85 @@
+# Test if the namespace of comprehension expr is isolated
+# type: ignore
+
+
+def func():
+    i = 0
+
+    def func2():
+        nonlocal i
+        i = 2
+        [print(i) for i in range(10)]  # listcomp
+        list(print(i) for i in range(10))  # genexpr
+        {print(i) for i in range(10)}  # setcomp
+        {print(i): None for i in range(10)}  # dictcomp
+
+    func2()
+    print(i)
+
+
+func()
+
+
+def func():
+    i = 0
+
+    def func2():
+        nonlocal i
+        i = 2
+
+    class Foo:
+        nonlocal i
+        # test: comp inside a class
+        [print(i) for i in range(10)]
+
+    print(i)
+
+
+func()
+
+
+def func():
+    i, j, k, m = 0, 0, 0, 0
+
+    def func2():
+        nonlocal i, j, k, m
+        i, j, k, m = 9, 9, 9, 9
+        lst = [(1, (2, 3)), (6, (7, 8))]
+
+        # test: multi generator + tuple target
+        [print(m, k, j, i) for (i, (j, k)) in lst for m in range(4)]
+
+    func2()
+    print(m, k, j, i)
+
+
+func()
+
+
+def func():
+    i, j, k = 0, 0, 0
+
+    def func2():
+        nonlocal i, j, k
+        i, j, k = 9, 9, 9
+
+        # test: nested comp
+        [
+            [
+                print(i),
+                [
+                    [
+                        print(j),
+                        [print(k) for k in range(4)],
+                    ]
+                    for j in range(4)
+                ],
+            ]
+            for i in range(4)
+        ]
+
+    func2()
+    print(k, j, i)
+
+
+func()

--- a/tests/test_cases/comprehension.py
+++ b/tests/test_cases/comprehension.py
@@ -23,14 +23,13 @@ func()
 def func():
     i = 0
 
-    def func2():
-        nonlocal i
-        i = 2
-
     class Foo:
         nonlocal i
         # test: comp inside a class
         [print(i) for i in range(10)]
+
+        # test: nested comp inside a class, with global names used.
+        [[print(i), [print(bin(j)) for j in range(5)]] for i in range(10)]
 
     print(i)
 
@@ -83,3 +82,21 @@ def func():
 
 
 func()
+
+
+# test: a function is named "listcomp"
+# "listcomp" is used as the name of listcomp symbol table. (py < 3.12)
+# this conflict should be handled properly.
+def listcomp(a=[i for i in range(3)]):  # just for test, don't use kwarg like this.
+    b = 0
+
+    def func2():
+        nonlocal b
+        b = 1
+
+    func2()
+    print(b)
+    print(a)
+
+
+listcomp()


### PR DESCRIPTION
- Fix #1 
- Fix `AttributeError` when lambda/comprehension uses global name in a class namespace.
  Like this:
    ````py
    class Foo:
        [print(i) for i in range(10)]
        lambda :print("xd")
    ````