### PR TITLE
Fix compatibility with 1.0.0

### DIFF
--- a/oneliner/__init__.py
+++ b/oneliner/__init__.py
@@ -7,8 +7,11 @@ import ast
 import symtable
 
 
-def convert_code_string(code: str, filename="<string>"):
+def convert_code_string(code: str, filename="<string>", use_new_unparser=False):
     ast_root = ast.parse(code, filename, "exec")
     symtable_root = symtable.symtable(code, filename, "exec")
     out = OnelinerConvertor().cvt(ast_root, symtable_root)
-    return unparse(out)
+    if use_new_unparser:
+        return unparse(out)
+    else:
+        return ast.unparse(out).replace("\n", "")

--- a/oneliner/__main__.py
+++ b/oneliner/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 
 import oneliner
+import oneliner.version
 
 parser = argparse.ArgumentParser(
     description="Convert python scripts into oneliner expression."
@@ -12,6 +13,15 @@ parser.add_argument(
     help="The filename of the python script to be converted",
 )
 
+ver = oneliner.version.oneliner_version
+dev = "-dev" if oneliner.version.dev else ""
+parser.add_argument(
+    "-v",
+    "--version",
+    action="version",
+    version=f"Oneliner-Py-{ver[0]}.{ver[1]}.{ver[2]}{dev}",
+)
+
 parser.add_argument(
     "-o",
     "--output",
@@ -20,12 +30,22 @@ parser.add_argument(
     "Oneliner-Py will print the result to the screen.",
 )
 
+parser.add_argument(
+    "--unparser",
+    type=str,
+    default="ast.unparse",
+    choices=["ast.unparse", "oneliner"],
+)
+
 args = parser.parse_args()
 
 with open(args.input_filename, "r", encoding="utf8") as infile:
     script = infile.read()
 
-converted = oneliner.convert_code_string(script)
+if args.unparser == "ast.unparse":
+    converted = oneliner.convert_code_string(script, use_new_unparser=False)
+else:
+    converted = oneliner.convert_code_string(script, use_new_unparser=True)
 
 if args.output is not None:
     with open(args.output, "w", encoding="utf8") as outfile:

--- a/oneliner/version.py
+++ b/oneliner/version.py
@@ -1,0 +1,2 @@
+oneliner_version = (1,1,0)
+dev = True

--- a/oneliner/version.py
+++ b/oneliner/version.py
@@ -1,2 +1,2 @@
-oneliner_version = (1,1,0)
+oneliner_version = (1, 1, 0)
 dev = True


### PR DESCRIPTION
Add `-v` and `--unparser` arguments
Allow users to check the version and choose the unparser.
By default the unparser will be ast.unparse for compatibility