### PR TITLE
[20241210 Big PR]

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -23,3 +23,5 @@ jobs:
             python3 -m isort ./ --check
             python3 -m black ./ --check
             python3 -m ruff check ./
+            python3 -m pip install .
+            python3 -m mypy oneliner

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+[![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 
 Convert python scripts into **oneliner** expression.  
 

--- a/oneliner/__init__.py
+++ b/oneliner/__init__.py
@@ -1,5 +1,7 @@
 from oneliner.convert import OnelinerConvertor
 from oneliner.expr_unparse import unparse
+from oneliner.config import Configs
+import oneliner.utils
 
 __all__ = ["OnelinerConvertor", "convert_code_string"]
 
@@ -7,11 +9,21 @@ import ast
 import symtable
 
 
-def convert_code_string(code: str, filename="<string>", use_new_unparser=False):
+def convert_code_string(code: str, filename="<string>", configs:Configs|None=None):
+    if configs is None:
+        configs = Configs()
+    
+    # todo: don't change it globally
+    if configs.expr_wrapper=="chain_call":
+        oneliner.utils._wrap_expr = oneliner.utils.chain_call_wrapper
+    else:
+        oneliner.utils._wrap_expr = oneliner.utils.list_wrapper
+
     ast_root = ast.parse(code, filename, "exec")
     symtable_root = symtable.symtable(code, filename, "exec")
     out = OnelinerConvertor().cvt(ast_root, symtable_root)
-    if use_new_unparser:
+
+    if configs.unparser=="oneliner":
         return unparse(out)
     else:
         return ast.unparse(out).replace("\n", "")

--- a/oneliner/__init__.py
+++ b/oneliner/__init__.py
@@ -1,29 +1,22 @@
-import oneliner.utils
 from oneliner.config import Configs
-from oneliner.convert import OnelinerConvertor
+from oneliner.convert import convert
 from oneliner.expr_unparse import expr_unparse
 
-__all__ = ["OnelinerConvertor", "convert_code_string"]
+__all__ = ["convert_code_string"]
 
 import ast
 import symtable
 
 
-def convert_code_string(code: str, filename="<string>", configs:Configs|None=None):
+def convert_code_string(code: str, filename="<string>", configs: Configs | None = None):
     if configs is None:
         configs = Configs()
-    
-    # todo: don't change it globally
-    if configs.expr_wrapper=="chain_call":
-        oneliner.utils._wrap_expr = oneliner.utils.chain_call_wrapper
-    else:
-        oneliner.utils._wrap_expr = oneliner.utils.list_wrapper
 
     ast_root = ast.parse(code, filename, "exec")
     symtable_root = symtable.symtable(code, filename, "exec")
-    out = OnelinerConvertor().cvt(ast_root, symtable_root)
+    out = convert(ast_root, symtable_root, configs)
 
-    if configs.unparser=="oneliner":
+    if configs.unparser == "oneliner":
         return expr_unparse(out)
     else:
         return ast.unparse(out).replace("\n", "")

--- a/oneliner/__init__.py
+++ b/oneliner/__init__.py
@@ -1,7 +1,7 @@
-from oneliner.convert import OnelinerConvertor
-from oneliner.expr_unparse import unparse
-from oneliner.config import Configs
 import oneliner.utils
+from oneliner.config import Configs
+from oneliner.convert import OnelinerConvertor
+from oneliner.expr_unparse import expr_unparse
 
 __all__ = ["OnelinerConvertor", "convert_code_string"]
 
@@ -24,6 +24,6 @@ def convert_code_string(code: str, filename="<string>", configs:Configs|None=Non
     out = OnelinerConvertor().cvt(ast_root, symtable_root)
 
     if configs.unparser=="oneliner":
-        return unparse(out)
+        return expr_unparse(out)
     else:
         return ast.unparse(out).replace("\n", "")

--- a/oneliner/__main__.py
+++ b/oneliner/__main__.py
@@ -54,8 +54,14 @@ else:
 for input_config in args_configs:
     assert isinstance(input_config, str)
 
-    # todo: better error message
-    config_name, config_value = input_config.split("=")
+    splited_input_config = input_config.split("=")
+
+    if len(splited_input_config) != 2:
+        raise TypeError(
+            "Invalid syntax of -C parameter, expected -C<config_name>=<config_value>"
+        )
+
+    config_name, config_value = splited_input_config
 
     if not hasattr(cfg, config_name):
         raise ValueError(f"Unknown convig name '{config_name}'")

--- a/oneliner/__main__.py
+++ b/oneliner/__main__.py
@@ -1,18 +1,15 @@
 import argparse
 
 import oneliner
-import oneliner.version
 import oneliner.config
+import oneliner.version
 
 parser = argparse.ArgumentParser(
     description="Convert python scripts into oneliner expression."
 )
 
 parser.add_argument(
-    "-C",
-    action="append",
-    type=str,
-    help="Set configs of oneliner convertion"
+    "-C", action="append", type=str, help="Set configs of oneliner convertion"
 )
 
 parser.add_argument(
@@ -42,7 +39,6 @@ parser.add_argument(
 parser.add_argument(
     "--unparser",
     type=str,
-    default="ast.unparse",
     choices=["ast.unparse", "oneliner"],
 )
 
@@ -50,20 +46,29 @@ args = parser.parse_args()
 
 cfg = oneliner.config.Configs()
 
-for input_config in args.C:
+if args.C is None:
+    args_configs = []
+else:
+    args_configs = args.C
+
+for input_config in args_configs:
     assert isinstance(input_config, str)
-    
+
     # todo: better error message
     config_name, config_value = input_config.split("=")
 
-    setattr(cfg,config_name,config_value)
+    if not hasattr(cfg, config_name):
+        raise ValueError(f"Unknown convig name '{config_name}'")
+
+    setattr(cfg, config_name, config_value)
 
 if args.unparser is not None:
     import warnings
+
     warnings.warn(
         f"'--unparser {args.unparser}' is deprecated,"
         f" use '-Cunparser={args.unparser}' instead",
-        DeprecationWarning
+        DeprecationWarning,
     )
     cfg.unparser = args.unparser
 

--- a/oneliner/__main__.py
+++ b/oneliner/__main__.py
@@ -2,9 +2,17 @@ import argparse
 
 import oneliner
 import oneliner.version
+import oneliner.config
 
 parser = argparse.ArgumentParser(
     description="Convert python scripts into oneliner expression."
+)
+
+parser.add_argument(
+    "-C",
+    action="append",
+    type=str,
+    help="Set configs of oneliner convertion"
 )
 
 parser.add_argument(
@@ -30,6 +38,7 @@ parser.add_argument(
     "Oneliner-Py will print the result to the screen.",
 )
 
+# todo: remove in 1.3.0
 parser.add_argument(
     "--unparser",
     type=str,
@@ -39,13 +48,29 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+cfg = oneliner.config.Configs()
+
+for input_config in args.C:
+    assert isinstance(input_config, str)
+    
+    # todo: better error message
+    config_name, config_value = input_config.split("=")
+
+    setattr(cfg,config_name,config_value)
+
+if args.unparser is not None:
+    import warnings
+    warnings.warn(
+        f"'--unparser {args.unparser}' is deprecated,"
+        f" use '-Cunparser={args.unparser}' instead",
+        DeprecationWarning
+    )
+    cfg.unparser = args.unparser
+
 with open(args.input_filename, "r", encoding="utf8") as infile:
     script = infile.read()
 
-if args.unparser == "ast.unparse":
-    converted = oneliner.convert_code_string(script, use_new_unparser=False)
-else:
-    converted = oneliner.convert_code_string(script, use_new_unparser=True)
+converted = oneliner.convert_code_string(script, configs=cfg)
 
 if args.output is not None:
     with open(args.output, "w", encoding="utf8") as outfile:

--- a/oneliner/config.py
+++ b/oneliner/config.py
@@ -1,35 +1,35 @@
-from typing import Literal, Any
+from typing import Any, Literal
+
 
 class Cfg:
-    tp:Any
-    default:Any
-    value:Any
-    docs:str
+    tp: Any
+    default: Any
+    value: Any
+    docs: str
+
     def __init__(self, tp, default, docs=""):
         self.tp = tp
         self.default = default
         self.docs = docs
         self.value = default
-    
+
     def __set__(self, instance, value):
         # todo: verify the value
         self.value = value
-    
+
     def __get__(self, instance, owner=None):
         return self.value
 
+
 class Configs:
     unparser = Cfg(
-        Literal["ast.unparse","oneliner"],
+        Literal["ast.unparse", "oneliner"],
         "ast.unparse",
         "Choose the unparser",
     )
     expr_wrapper = Cfg(
-        Literal["list","chain_call"],
+        Literal["list", "chain_call"],
         "chain_call",
         "Choose the expr_wrapper",
     )
-    config_names = tuple(
-        name for name in locals() 
-        if not name.startswith("__")
-    )
+    config_names = tuple(name for name in locals() if not name.startswith("__"))

--- a/oneliner/config.py
+++ b/oneliner/config.py
@@ -1,0 +1,35 @@
+from typing import Literal, Any
+
+class Cfg:
+    tp:Any
+    default:Any
+    value:Any
+    docs:str
+    def __init__(self, tp, default, docs=""):
+        self.tp = tp
+        self.default = default
+        self.docs = docs
+        self.value = default
+    
+    def __set__(self, instance, value):
+        # todo: verify the value
+        self.value = value
+    
+    def __get__(self, instance, owner=None):
+        return self.value
+
+class Configs:
+    unparser = Cfg(
+        Literal["ast.unparse","oneliner"],
+        "ast.unparse",
+        "Choose the unparser",
+    )
+    expr_wrapper = Cfg(
+        Literal["list","chain_call"],
+        "chain_call",
+        "Choose the expr_wrapper",
+    )
+    config_names = tuple(
+        name for name in locals() 
+        if not name.startswith("__")
+    )

--- a/oneliner/config.py
+++ b/oneliner/config.py
@@ -1,11 +1,12 @@
-from typing import Any, Literal
+from typing import Any
 
 
 class Cfg:
-    tp: Any
+    tp: list | type
     default: Any
     value: Any
     docs: str
+    name: str
 
     def __init__(self, tp, default, docs=""):
         self.tp = tp
@@ -13,8 +14,20 @@ class Cfg:
         self.docs = docs
         self.value = default
 
+    def __set_name__(self, owner, name):
+        self.name = name
+
     def __set__(self, instance, value):
-        # todo: verify the value
+        # varify the input value
+        if isinstance(self.tp, list):
+            if value not in self.tp:
+                raise ValueError(
+                    f"Invalid value of config '{self.name}', "
+                    f"got '{value}', expected {self.tp}"
+                )
+        else:
+            if not isinstance(value, self.tp):
+                raise ValueError(f"Invalid value of config '{self.name}'")
         self.value = value
 
     def __get__(self, instance, owner=None):
@@ -23,12 +36,12 @@ class Cfg:
 
 class Configs:
     unparser = Cfg(
-        Literal["ast.unparse", "oneliner"],
+        ["ast.unparse", "oneliner"],
         "ast.unparse",
         "Choose the unparser",
     )
     expr_wrapper = Cfg(
-        Literal["list", "chain_call"],
+        ["list", "chain_call"],
         "chain_call",
         "Choose the expr_wrapper",
     )

--- a/oneliner/contex.py
+++ b/oneliner/contex.py
@@ -3,15 +3,17 @@ import typing
 
 import oneliner.utils as utils
 from oneliner.config import Configs
-from oneliner.namespaces import NamespaceGlobal
 
 
 class Context:
-    nsp_global: NamespaceGlobal
+    nsp_global: "NamespaceGlobal"
     configs: Configs
     expr_wraper: typing.Callable[[list[ast.expr]], ast.expr]
 
-    def __init__(self, nsp_global: NamespaceGlobal, configs: Configs) -> None:
+    def __init__(self, nsp_global: "NamespaceGlobal", configs: Configs) -> None:
         self.nsp_global = nsp_global
         self.configs = configs
         self.expr_wraper = utils.get_expr_wrapper(configs)
+
+
+from oneliner.namespaces import NamespaceGlobal  # fix circular import

--- a/oneliner/contex.py
+++ b/oneliner/contex.py
@@ -1,0 +1,17 @@
+import ast
+import typing
+
+import oneliner.utils as utils
+from oneliner.config import Configs
+from oneliner.namespaces import NamespaceGlobal
+
+
+class Context:
+    nsp_global: NamespaceGlobal
+    configs: Configs
+    expr_wraper: typing.Callable[[list[ast.expr]], ast.expr]
+
+    def __init__(self, nsp_global: NamespaceGlobal, configs: Configs) -> None:
+        self.nsp_global = nsp_global
+        self.configs = configs
+        self.expr_wraper = utils.get_expr_wrapper(configs)

--- a/oneliner/convert.py
+++ b/oneliner/convert.py
@@ -77,4 +77,4 @@ class OnelinerConvertor:
 
                     if len(self.pending_node_stack) == 0:
                         assert len(self.nsp_stack) == 1
-                        return utils.list_wrapper(result_nodes)
+                        return utils.chain_call_wrapper(result_nodes)

--- a/oneliner/convert.py
+++ b/oneliner/convert.py
@@ -7,9 +7,12 @@ from oneliner.pending_nodes import *
 
 
 class OnelinerConvertor:
-    def __init__(self):
-        self.pending_node_stack: list[PendingNode] = []
-        self.nsp_stack: list[Namespace] = []
+    pending_node_stack: list[PendingNode]
+    nsp_stack: list[Namespace]
+
+    def __init__(self) -> None:
+        self.pending_node_stack = []
+        self.nsp_stack = []
 
     _pending_map: dict[type[ast.AST], type[PendingNode]] = {
         ast.Module: PendingModule,
@@ -41,7 +44,7 @@ class OnelinerConvertor:
             )
         except KeyError as err:
             raise RuntimeError(
-                utils.ast_debug_info(node)
+                utils.ast_debug_info(node)  # type: ignore
                 + f"Unable to convert node '{type(node).__name__}'"
             ) from err
 
@@ -49,12 +52,15 @@ class OnelinerConvertor:
         """Get the stack top of self.pending_node_stack"""
         return self.pending_node_stack[-1]
 
-    def cvt(self, ast_root: ast.Module, symtable_root: symtable.SymbolTable) -> ast.AST:
+    def cvt(
+        self, ast_root: ast.Module, symtable_root: symtable.SymbolTable
+    ) -> ast.expr:
         self.nsp_global = generate_nsp(symtable_root)
         self.nsp_stack.append(self.nsp_global)
-        unconverted = ast_root
+        unconverted: None | ast.AST = ast_root
         result_nodes = None
         while True:
+            assert unconverted is not None  # to make type checker happy
             pending_node = self.get_pending_node(unconverted)
             self.pending_node_stack.append(pending_node)
             if pending_node.has_internal_namespace:

--- a/oneliner/convert.py
+++ b/oneliner/convert.py
@@ -4,7 +4,7 @@ import symtable
 import oneliner.utils as utils
 from oneliner.config import Configs
 from oneliner.contex import Context
-from oneliner.namespaces import *
+from oneliner.namespaces import Namespace, generate_nsp
 from oneliner.pending_nodes import *
 
 ast2pending: dict[type[ast.AST], type[PendingNode]] = {

--- a/oneliner/expr_unparse.py
+++ b/oneliner/expr_unparse.py
@@ -111,7 +111,7 @@ def get_UnaryOp_precedence(op):
     return INF
 
 
-ast_prec_map: dict[type[AST] : int] = {
+ast_prec_map: dict[type[AST], int] = {
     Constant: PERC_NAME,
     JoinedStr: PERC_NAME,
     FormattedValue: PERC_NAME,
@@ -347,6 +347,7 @@ def unparse_NamedExpr(node: NamedExpr):
 def unparse_Lambda(node: Lambda):
     body = yield PREC_LAMBDA, node.body
     arg_def_list = []
+    default: expr | None
 
     # handle posonly args
     for posonly in node.args.posonlyargs:
@@ -499,7 +500,7 @@ class _Node:
             self.gen = gen_func(node)
 
 
-def unparse(node: expr):
+def expr_unparse(node: expr) -> str:
     stack: list[_Node] = []
     stack.append(_Node(PREC_EXPR, node, '"'))
     converted: str | None = None
@@ -515,4 +516,5 @@ def unparse(node: expr):
             if inner_node.precedence > inner_node.outer_precedence:
                 converted = f"({converted})"
 
+    assert converted is not None
     return converted

--- a/oneliner/pending_nodes.py
+++ b/oneliner/pending_nodes.py
@@ -39,10 +39,10 @@ class PendingNode:
         self.nsp = nsp
         self.nsp_global = nsp_global
 
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         raise NotImplementedError()  # pragma: no cover
 
-    def _iter_nodes(self) -> typing.Generator[AST, list[AST], None]:
+    def _iter_nodes(self) -> typing.Generator[AST, list[expr], None]:
         return None
         yield AST()
 
@@ -53,12 +53,14 @@ class PendingNode:
 
 
 class PendingModule(PendingNode):
+    converted_body: list[expr]
+
     def __init__(self, node: Module, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
         self.node = node
         self.converted_body = []
 
-    def _iter_nodes(self) -> typing.Generator[AST, list[AST], None]:
+    def _iter_nodes(self) -> typing.Generator[AST, list[expr], None]:
         for node in self.node.body:
             self.converted_body.extend((yield node))
 
@@ -73,7 +75,7 @@ class PendingModule(PendingNode):
         )
         self.converted_body.insert(0, import_itertools_ast)
 
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         if self.nsp_global.use_itertools:
             self._insert_import_lib("itertools", "itertools")
         if self.nsp_global.use_importlib:
@@ -92,7 +94,7 @@ class PendingExpr(PendingNode):
         super().__init__(node, nsp, nsp_global)
         self.node = node
 
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         return [expr_transf(self.nsp, self.node.value)]
 
 
@@ -111,14 +113,14 @@ class _PendingCompoundStmt(PendingNode):
 
     def _iter_branch(
         self,
-        converted_branch: list[AST],
+        converted_branch: list[expr],
         branch: list[stmt],
         get_interrupt_cnt,
         get_flow_control_expr,
-    ) -> typing.Generator[AST, list[AST], None]:
+    ) -> typing.Generator[AST, list[expr], None]:
         initial_interrupt_cnt = get_interrupt_cnt()
 
-        converting = []
+        converting: list[expr] = []
         stack = [converting]
         for node in branch:
             if get_interrupt_cnt() > initial_interrupt_cnt:
@@ -147,6 +149,9 @@ class _PendingCompoundStmt(PendingNode):
 
 
 class PendingIf(_PendingCompoundStmt):
+    converted_body: list[expr]
+    converted_orelse: list[expr]
+
     def __init__(self, node: If, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
         self.node = node
@@ -154,7 +159,7 @@ class PendingIf(_PendingCompoundStmt):
         self.converted_body = []
         self.converted_orelse = []
 
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         return [
             IfExp(
                 test=expr_transf(self.nsp, self.node.test),
@@ -163,7 +168,7 @@ class PendingIf(_PendingCompoundStmt):
             )
         ]
 
-    def _iter_nodes(self) -> typing.Generator[AST, list[AST], None]:
+    def _iter_nodes(self) -> typing.Generator[AST, list[expr], None]:
         if self.nsp.loop_stack:
             # if inside a loop
             get_interrupt_cnt = lambda: self.nsp.loop_stack[-1].interrupt_cnt
@@ -191,15 +196,18 @@ class PendingIf(_PendingCompoundStmt):
         )
 
 
-class _PendingLoop(_PendingCompoundStmt):
-    node: While | For  # Original node
+T = typing.TypeVar("T", While, For)
+
+
+class _PendingLoop(_PendingCompoundStmt, typing.Generic[T]):
+    node: T  # Original node
     flow_ctrl_interrupt_expr: Name
     flow_ctrl_interrupt_used: bool
     interrupt_node_bodies: list[
-        list[AST]
+        list[expr]
     ]  # list of bodies of converted return/break/continue nodes
-    converted_body: list[AST]  # converted body branch
-    converted_orelse: list[AST]  # converted orelse branch
+    converted_body: list[expr]  # converted body branch
+    converted_orelse: list[expr]  # converted orelse branch
     interrupt_cnt: int  # Continue, Break and Return will increase this counter
     break_cnt: int  # Break and Return will increase this counter
 
@@ -207,7 +215,7 @@ class _PendingLoop(_PendingCompoundStmt):
         self.flow_ctrl_interrupt_used = True
         return self.flow_ctrl_interrupt_expr
 
-    def _iter_nodes(self) -> typing.Generator[AST, list[AST], None]:
+    def _iter_nodes(self) -> typing.Generator[AST, list[expr], None]:
         yield from self._iter_branch(
             self.converted_body,
             self.node.body,
@@ -238,8 +246,7 @@ class _PendingLoop(_PendingCompoundStmt):
         )
 
 
-class PendingWhile(_PendingLoop):
-    node: While
+class PendingWhile(_PendingLoop[While]):
 
     def __init__(self, node: While, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
@@ -261,8 +268,8 @@ class PendingWhile(_PendingLoop):
 
         self.nsp_global.use_itertools = True
 
-    def get_result(self) -> list[AST]:
-        while_loop_final = []
+    def get_result(self) -> list[expr]:
+        while_loop_final: list[expr] = []
 
         # if there is break, reset the flow-control var
         # and enable itertools
@@ -306,6 +313,7 @@ class PendingWhile(_PendingLoop):
             while_loop_test = expr_transf(self.nsp, self.node.test)
 
         # "orelse" runs if there's no break
+        while_loop_orelse: expr
         if self.break_cnt:
             while_loop_orelse = IfExp(
                 test=UnaryOp(op=Not(), operand=self.flow_ctrl_break_expr),
@@ -365,8 +373,7 @@ class PendingWhile(_PendingLoop):
         return while_loop_final
 
 
-class PendingFor(_PendingLoop):
-    node: For
+class PendingFor(_PendingLoop[For]):
 
     def __init__(self, node: For, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
@@ -386,7 +393,7 @@ class PendingFor(_PendingLoop):
 
         self.nsp.loop_stack.append(self)
 
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         # if no break/continue/return used
         # use the simplest list comprehension
         if self.interrupt_cnt == 0 and len(self.node.orelse) == 0:
@@ -404,7 +411,7 @@ class PendingFor(_PendingLoop):
                 )
             ]
 
-        for_loop_final = []
+        for_loop_final: list[expr] = []
 
         # init the flow-control vars
         if self.flow_ctrl_interrupt_used:
@@ -444,6 +451,7 @@ class PendingFor(_PendingLoop):
             for_loop_final.append(iter_wrapper_instance)
 
         # "orelse" runs if there's no break
+        for_loop_orelse: expr
         if self.break_cnt:
             for_loop_orelse = IfExp(
                 test=UnaryOp(
@@ -495,8 +503,8 @@ class PendingBreak(PendingNode):
         self.loop.break_cnt += 1
         self.loop.interrupt_cnt += 1
 
-    def get_result(self) -> list[AST]:
-        return_value: list[AST] = []
+    def get_result(self) -> list[expr]:
+        return_value: list[expr] = []
         if isinstance(self.loop, PendingWhile):
             return_value.append(
                 NamedExpr(
@@ -531,14 +539,14 @@ class PeindingContinue(PendingNode):
         self.loop = self.nsp.loop_stack[-1]
         self.loop.interrupt_cnt += 1
 
-    def get_result(self) -> list[AST]:
-        return_value = []
+    def get_result(self) -> list[expr]:
+        return_value: list[expr] = []
         self.loop.interrupt_node_bodies.append(return_value)
         return [List(elts=return_value, ctx=Load())]
 
 
 class PendingPass(PendingNode):
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         return [Constant(value=...)]
 
 
@@ -549,7 +557,7 @@ class PendingAssign(PendingNode):
         super().__init__(node, nsp, nsp_global)
         self.node = node
 
-    def assign_auto(self, target: AST, value: expr) -> list[AST]:
+    def assign_auto(self, target: AST, value: expr) -> list[expr]:
         if isinstance(target, Name):
             return [self.assign_name(target, value)]
         elif isinstance(target, Attribute):
@@ -579,7 +587,7 @@ class PendingAssign(PendingNode):
             keywords=[],
         )
 
-    def assign_attribute(self, target: Attribute, value: expr) -> AST:
+    def assign_attribute(self, target: Attribute, value: expr) -> expr:
         return Call(
             func=Name(id="setattr", ctx=Load()),
             args=[
@@ -590,12 +598,14 @@ class PendingAssign(PendingNode):
             keywords=[],
         )
 
-    def assign_tuple_list(self, target: Tuple | List, value: expr) -> list[AST]:
+    def assign_tuple_list(self, target: Tuple | List, value: expr) -> list[expr]:
         """
         Recursion warning
         """
         return_list = []
         have_starred = False
+        value_subscript: expr
+        slice_upper: Constant | None
         for index, sub_target in enumerate(target.elts):
             if isinstance(sub_target, Starred):
                 if have_starred:
@@ -640,13 +650,14 @@ class PendingAssign(PendingNode):
             return_list.extend(self.assign_auto(sub_target, value_subscript))
         return return_list
 
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         if self.node.value is None:
             return []
 
-        return_list = []
+        return_list: list[expr] = []
         assign_value = expr_transf(self.nsp, self.node.value)
 
+        assign_targets: list[expr]
         if isinstance(self.node, AnnAssign):
             assign_targets = [self.node.target]
         else:
@@ -695,10 +706,11 @@ class PendingAugAssign(PendingNode):
     }
 
     def _aug_assign_expr(
-        self, target: expr, op: operator, value: AST, fallback: AST | None = None
-    ):
+        self, target: expr, op: operator, value: expr, fallback: expr | None = None
+    ) -> expr:
         op_name = self._op_dict[type(op)]
         if fallback is None:
+            assert isinstance(target, Name)
             fallback = NamedExpr(
                 target=target, value=BinOp(left=target, op=op, right=value)
             )
@@ -716,8 +728,8 @@ class PendingAugAssign(PendingNode):
             orelse=fallback,
         )
 
-    def get_result(self) -> list[AST]:
-        return_list = []
+    def get_result(self) -> list[expr]:
+        return_list: list[expr] = []
         tmp_target_name = Name(id=ol_name(OL_AUGASSIGN_TMP))
         assign_value = expr_transf(self.nsp, self.node.value)
         if isinstance(self.node.target, Name):
@@ -817,6 +829,7 @@ class PendingAugAssign(PendingNode):
 class PendingFunctionDef(_PendingCompoundStmt):
     has_internal_namespace = True
     internal_nsp: NamespaceFunction
+    converted_body: list[expr]
 
     def __init__(self, node: FunctionDef, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
@@ -835,7 +848,15 @@ class PendingFunctionDef(_PendingCompoundStmt):
 
         # copy args and filter annotations
         original_args = node.args
-        self.converted_args = converted_args = arguments()
+        self.converted_args = converted_args = arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        )
 
         converted_args.posonlyargs = []
         for _arg in original_args.posonlyargs:
@@ -867,7 +888,7 @@ class PendingFunctionDef(_PendingCompoundStmt):
     def get_internal_namespace(self):
         return self.internal_nsp
 
-    def _iter_nodes(self) -> typing.Generator[AST, list[AST], None]:
+    def _iter_nodes(self) -> typing.Generator[AST, list[expr], None]:
         yield from self._iter_branch(
             self.converted_body,
             self.node.body,
@@ -875,8 +896,8 @@ class PendingFunctionDef(_PendingCompoundStmt):
             self.internal_nsp.get_flow_ctrl_expr,
         )
 
-    def get_result(self) -> list[AST]:
-        body: list[AST] = []
+    def get_result(self) -> list[expr]:
+        body: list[expr] = []
         body.append(
             NamedExpr(
                 target=self.internal_nsp.return_value_expr,
@@ -905,25 +926,31 @@ class PendingFunctionDef(_PendingCompoundStmt):
                 )
 
         if len(self.internal_nsp.inner_nonlocal_names):
-            nonlocal_dict_keys = []
-            nonlocal_dict_values = []
+            nonlocal_dict_keys: list[expr] = []
+            nonlocal_dict_values: list[expr] = []
             for nonlocal_param in self.internal_nsp.nonlocal_parameters:
                 nonlocal_dict_keys.append(Constant(value=nonlocal_param))
                 nonlocal_dict_values.append(Name(id=nonlocal_param, ctx=Load()))
             body.append(
                 NamedExpr(
                     target=self.internal_nsp.nonlocal_dict_expr,
-                    value=Dict(keys=nonlocal_dict_keys, values=nonlocal_dict_values),
+                    value=Dict(
+                        keys=nonlocal_dict_keys,  # type: ignore
+                        values=nonlocal_dict_values,
+                    ),
                 )
             )
 
         body.extend(self.converted_body)
         body.append(self.internal_nsp.return_value_expr)
 
+        body_expr: expr
         body_expr = Lambda(
             args=self.converted_args,
             body=Subscript(
-                value=utils.list_wrapper(body), # todo: not the full body needs list_wrapper
+                value=utils.list_wrapper(
+                    body
+                ),  # todo: not the full body needs list_wrapper
                 slice=Constant(value=-1),
                 ctx=Load(),
             ),
@@ -961,8 +988,8 @@ class PendingReturn(PendingNode):
             loop.break_cnt += 1
             loop.interrupt_cnt += 1
 
-    def get_result(self) -> list[AST]:
-        return_list: list[AST] = []
+    def get_result(self) -> list[expr]:
+        return_list: list[expr] = []
         if self.node.value is not None:
             return_list.append(
                 NamedExpr(
@@ -998,18 +1025,19 @@ class PendingReturn(PendingNode):
 
 
 class PendingGlobal(PendingNode):
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         return []
 
 
 class PendingNonlocal(PendingNode):
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         return []
 
 
 class PendingClassDef(_PendingCompoundStmt):
     has_internal_namespace = True
     internal_nsp: NamespaceClass
+    converted_body: list[expr]
 
     def __init__(self, node: ClassDef, nsp: Namespace, nsp_global: NamespaceGlobal):
         super().__init__(node, nsp, nsp_global)
@@ -1031,7 +1059,7 @@ class PendingClassDef(_PendingCompoundStmt):
     def get_internal_namespace(self) -> Namespace:
         return self.internal_nsp
 
-    def _iter_nodes(self) -> typing.Generator[AST, list[AST], None]:
+    def _iter_nodes(self) -> typing.Generator[AST, list[expr], None]:
         yield from self._iter_branch(
             self.converted_body,
             self.node.body,
@@ -1039,8 +1067,8 @@ class PendingClassDef(_PendingCompoundStmt):
             utils.never_call,
         )
 
-    def get_result(self) -> list[AST]:
-        return_list: list[AST] = []
+    def get_result(self) -> list[expr]:
+        return_list: list[expr] = []
 
         class_bases = [expr_transf(self.nsp, _expr) for _expr in self.node.bases]
 
@@ -1076,7 +1104,7 @@ class PendingClassDef(_PendingCompoundStmt):
             )
         )
 
-        class_body: list[AST] = []
+        class_body: list[expr] = []
         class_body.append(
             NamedExpr(  # one step of injecting the __class__ cell
                 target=Name(id="__class__", ctx=Store()),
@@ -1158,7 +1186,7 @@ class PendingImport(PendingNode):
         self.node = node
         self.nsp_global.use_importlib = True
 
-    def get_result(self) -> list[AST]:
+    def get_result(self) -> list[expr]:
         result = []
         for _alias in self.node.names:
             if _alias.asname is None:
@@ -1188,8 +1216,8 @@ class PendingImportFrom(PendingNode):
         super().__init__(node, nsp, nsp_global)
         self.node = node
 
-    def get_result(self) -> list[AST]:
-        result = []
+    def get_result(self) -> list[expr]:
+        result: list[expr] = []
         tmp_mod_name = ol_name(OL_IMPORT_TMP)
 
         if self.node.module is None:
@@ -1197,7 +1225,7 @@ class PendingImportFrom(PendingNode):
         else:
             mod_name = self.node.module
 
-        from_list = []
+        from_list: list[expr] = []
         for _alias in self.node.names:
             from_list.append(Constant(value=_alias.name))
 

--- a/oneliner/pending_nodes.py
+++ b/oneliner/pending_nodes.py
@@ -139,7 +139,7 @@ class _PendingCompoundStmt(PendingNode):
             stack[-1].append(
                 IfExp(
                     test=UnaryOp(op=Not(), operand=get_flow_control_expr()),
-                    body=utils.list_wrapper(wrapped),
+                    body=utils.wrap_expr(wrapped),
                     orelse=Constant(value=...),
                 )
             )
@@ -158,8 +158,8 @@ class PendingIf(_PendingCompoundStmt):
         return [
             IfExp(
                 test=expr_transf(self.nsp, self.node.test),
-                body=utils.list_wrapper(self.converted_body),
-                orelse=utils.list_wrapper(self.converted_orelse),
+                body=utils.wrap_expr(self.converted_body),
+                orelse=utils.wrap_expr(self.converted_orelse),
             )
         ]
 
@@ -309,15 +309,15 @@ class PendingWhile(_PendingLoop):
         if self.break_cnt:
             while_loop_orelse = IfExp(
                 test=UnaryOp(op=Not(), operand=self.flow_ctrl_break_expr),
-                body=utils.list_wrapper(self.converted_orelse),
+                body=utils.wrap_expr(self.converted_orelse),
                 orelse=Constant(value=...),
             )
         else:
-            while_loop_orelse = utils.list_wrapper(self.converted_orelse)
+            while_loop_orelse = utils.wrap_expr(self.converted_orelse)
 
         # the main body of the oneliner while loop
         while_loop_body = ListComp(
-            elt=utils.list_wrapper(self.converted_body),
+            elt=utils.wrap_expr(self.converted_body),
             generators=[
                 comprehension(
                     target=Name(id="_", ctx=Store()),
@@ -392,7 +392,7 @@ class PendingFor(_PendingLoop):
         if self.interrupt_cnt == 0 and len(self.node.orelse) == 0:
             return [
                 ListComp(
-                    elt=utils.list_wrapper(self.converted_body),
+                    elt=utils.wrap_expr(self.converted_body),
                     generators=[
                         comprehension(
                             target=self.node.target,
@@ -454,15 +454,15 @@ class PendingFor(_PendingLoop):
                         ctx=Load(),
                     ),
                 ),
-                body=utils.list_wrapper(self.converted_orelse),
+                body=utils.wrap_expr(self.converted_orelse),
                 orelse=Constant(value=...),
             )
         else:
-            for_loop_orelse = utils.list_wrapper(self.converted_orelse)
+            for_loop_orelse = utils.wrap_expr(self.converted_orelse)
 
         # the main body of the oneliner for loop
         for_loop_body = ListComp(
-            elt=utils.list_wrapper(self.converted_body),
+            elt=utils.wrap_expr(self.converted_body),
             generators=[
                 comprehension(
                     target=self.node.target,
@@ -923,7 +923,7 @@ class PendingFunctionDef(_PendingCompoundStmt):
         body_expr = Lambda(
             args=self.converted_args,
             body=Subscript(
-                value=utils.list_wrapper(body),
+                value=utils.list_wrapper(body), # todo: not the full body needs list_wrapper
                 slice=Constant(value=-1),
                 ctx=Load(),
             ),

--- a/oneliner/pending_nodes.py
+++ b/oneliner/pending_nodes.py
@@ -30,7 +30,7 @@ __all__ = [
 
 
 class PendingNode:
-    def __init__(self, node: AST, nsp: Namespace, context: Context):
+    def __init__(self, node: AST, nsp: Namespace, context: "Context"):
         self.iter_node = self._iter_nodes()
         self.nsp = nsp
         self.nsp_global = context.nsp_global
@@ -936,16 +936,17 @@ class PendingFunctionDef(_PendingCompoundStmt):
                 )
             )
 
-        body.extend(self.converted_body)
+        if self.context.configs.expr_wrapper == "list":
+            body.extend(self.converted_body)
+        else:
+            body.append(self.context.expr_wraper(self.converted_body))
         body.append(self.internal_nsp.return_value_expr)
+        body_expr = utils.list_wrapper(body)
 
-        body_expr: expr
         body_expr = Lambda(
             args=self.converted_args,
             body=Subscript(
-                value=utils.list_wrapper(
-                    body
-                ),  # todo: not the full body needs list_wrapper
+                value=body_expr,
                 slice=Constant(value=-1),
                 ctx=Load(),
             ),

--- a/oneliner/reserved_identifiers.py
+++ b/oneliner/reserved_identifiers.py
@@ -18,7 +18,7 @@ OL_NONLOCAL_DICT: _ol_reserved_name = "__ol_nonlocal_{}"
 OL_CLASS_DICT: _ol_reserved_name = "__ol_classnsp_{}"
 OL_CLASS_LOADER: _ol_reserved_name = "__ol_loader_{}"
 OL_IMPORT_TMP: _ol_reserved_name = "__ol_mod_{}"
-
+OL_RUN: _ol_reserved_name = "__ol_run"
 
 def ol_name(name: _ol_reserved_name):
     return name.format(utils.unique_id())

--- a/oneliner/reserved_identifiers.py
+++ b/oneliner/reserved_identifiers.py
@@ -20,5 +20,6 @@ OL_CLASS_LOADER: _ol_reserved_name = "__ol_loader_{}"
 OL_IMPORT_TMP: _ol_reserved_name = "__ol_mod_{}"
 OL_RUN: _ol_reserved_name = "__ol_run"
 
+
 def ol_name(name: _ol_reserved_name):
     return name.format(utils.unique_id())

--- a/oneliner/utils.py
+++ b/oneliner/utils.py
@@ -2,6 +2,8 @@ import random
 import typing
 from ast import *
 
+from oneliner.reserved_identifiers import OL_RUN
+
 
 def unique_id() -> str:
     return "".join(random.choices("abcdefghijklmnopqrstuvwxyz", k=10))
@@ -23,34 +25,30 @@ def convert_slice(_slice: Slice) -> Call:
         keywords=[],
     )
 
-
-def list_wrapper(nodes: list[AST]) -> AST:
-    """
-    Wrap a list of nodes as an `ast.List` node
-    """
+def wrap_expr(nodes: list[expr]) -> expr:
+    """Wrap a list of expr nodes as one expr"""
     if len(nodes) == 0:
         return Constant(value=...)
     if len(nodes) == 1:
         return nodes[0]
+
+    return _wrap_expr(nodes)
+
+def list_wrapper(nodes: list[expr]) -> expr:
     return List(elts=nodes, ctx=Load())
 
-
-def chain_call_wrapper(nodes: list[AST]) -> AST:
-    if len(nodes) == 0:
-        return Constant(value=...)
-    if len(nodes) == 1:
-        return nodes[0]
+def chain_call_wrapper(nodes: list[expr]) -> expr:
     runner = NamedExpr(
-        target=Name(id="__on_run", ctx=Store()),
+        target=Name(id=OL_RUN, ctx=Store()),
         value=Lambda(
             args=arguments(
                 posonlyargs=[],
-                args=[arg(arg="arg")],
+                args=[arg(arg="_")],
                 kwonlyargs=[],
                 kw_defaults=[],
                 defaults=[],
             ),
-            body=Name(id="__on_run", ctx=Load()),
+            body=Name(id=OL_RUN, ctx=Load()),
         ),
     )
     call = Call(
@@ -64,6 +62,7 @@ def chain_call_wrapper(nodes: list[AST]) -> AST:
 
     return call
 
+_wrap_expr = chain_call_wrapper
 
 def never_call(*args, **kwargs) -> typing.NoReturn:
     raise RuntimeError("this function should never be called")  # pragma: no cover

--- a/oneliner/utils.py
+++ b/oneliner/utils.py
@@ -1,6 +1,6 @@
 import random
 import typing
-from ast import AST, Call, Constant, List, Load, Name, Slice
+from ast import *
 
 
 def unique_id() -> str:
@@ -33,6 +33,36 @@ def list_wrapper(nodes: list[AST]) -> AST:
     if len(nodes) == 1:
         return nodes[0]
     return List(elts=nodes, ctx=Load())
+
+
+def chain_call_wrapper(nodes: list[AST]) -> AST:
+    if len(nodes) == 0:
+        return Constant(value=...)
+    if len(nodes) == 1:
+        return nodes[0]
+    runner = NamedExpr(
+        target=Name(id="__on_run", ctx=Store()),
+        value=Lambda(
+            args=arguments(
+                posonlyargs=[],
+                args=[arg(arg="arg")],
+                kwonlyargs=[],
+                kw_defaults=[],
+                defaults=[],
+            ),
+            body=Name(id="__on_run", ctx=Load()),
+        ),
+    )
+    call = Call(
+        func=runner,
+        args=[nodes[0]],
+        keywords=[],
+    )
+    for node in nodes[1:]:
+        call = Call(func=call, args=[], keywords=[])
+        call.args.append(node)
+
+    return call
 
 
 def never_call(*args, **kwargs) -> typing.NoReturn:

--- a/oneliner/utils.py
+++ b/oneliner/utils.py
@@ -2,6 +2,7 @@ import random
 import typing
 from ast import *
 
+from oneliner.config import Configs
 from oneliner.reserved_identifiers import OL_RUN
 
 
@@ -24,16 +25,6 @@ def convert_slice(_slice: Slice) -> Call:
         ],
         keywords=[],
     )
-
-
-def wrap_expr(nodes: list[expr]) -> expr:
-    """Wrap a list of expr nodes as one expr"""
-    if len(nodes) == 0:
-        return Constant(value=...)
-    if len(nodes) == 1:
-        return nodes[0]
-
-    return _wrap_expr(nodes)
 
 
 def list_wrapper(nodes: list[expr]) -> expr:
@@ -66,7 +57,22 @@ def chain_call_wrapper(nodes: list[expr]) -> expr:
     return call
 
 
-_wrap_expr = chain_call_wrapper
+def get_expr_wrapper(configs: Configs):
+    if configs.expr_wrapper == "chain_call":
+        _wrapper_internal = chain_call_wrapper
+    else:
+        _wrapper_internal = list_wrapper
+
+    def wraper(nodes: list[expr]) -> expr:
+        """Wrap a list of expr nodes as one expr"""
+        if len(nodes) == 0:
+            return Constant(value=...)
+        if len(nodes) == 1:
+            return nodes[0]
+
+        return _wrapper_internal(nodes)
+
+    return wraper
 
 
 def never_call(*args, **kwargs) -> typing.NoReturn:

--- a/oneliner/utils.py
+++ b/oneliner/utils.py
@@ -25,6 +25,7 @@ def convert_slice(_slice: Slice) -> Call:
         keywords=[],
     )
 
+
 def wrap_expr(nodes: list[expr]) -> expr:
     """Wrap a list of expr nodes as one expr"""
     if len(nodes) == 0:
@@ -34,8 +35,10 @@ def wrap_expr(nodes: list[expr]) -> expr:
 
     return _wrap_expr(nodes)
 
+
 def list_wrapper(nodes: list[expr]) -> expr:
     return List(elts=nodes, ctx=Load())
+
 
 def chain_call_wrapper(nodes: list[expr]) -> expr:
     runner = NamedExpr(
@@ -62,11 +65,13 @@ def chain_call_wrapper(nodes: list[expr]) -> expr:
 
     return call
 
+
 _wrap_expr = chain_call_wrapper
+
 
 def never_call(*args, **kwargs) -> typing.NoReturn:
     raise RuntimeError("this function should never be called")  # pragma: no cover
 
 
-def ast_debug_info(node: AST):
+def ast_debug_info(node: stmt | expr):
     return f"At line {node.lineno}, col {node.col_offset}: "

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ coverage
 black
 isort
 ruff
-# todo: add mypy check
+mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ coverage
 black
 isort
 ruff
+# todo: add mypy check


### PR DESCRIPTION
## 1. Add a brand new wrapper: "chain_call" wrapper
For a given class with `__del__` method specified like 
```py
class B:
    def __del__(self):
        print(123456)
```
Do folowing operations
```py
b = B()
b = None
print(654321)
```
At line 2, instance `B()` is collected by GC, `__del__` method is called, `123456` is printed. Then, at line 3, `654321` is printed.

With the original "list" wrapper, we get following converted code
```py
[b:=B(),b:=None,print(654321)]
```
We can find, even though b is set to `None`, the `B()` is not deleted until the whole list is collected by GC. That means, this piece of code will print `654321` first, then `123456`. The behavior is inconsistent with the original code.

So the "chain_call" wrapper is born
```py
(__ol_run:=lambda _:__ol_run)(b:=B())(b:=None)(print(654321))
```
The value of each expression in the wrapper will be destroyed instantly after the evaluation of the expression. The delayed-delete wont happen any more. The code prints `123456` then `654321` now.
## 2. `-C` parameter in command line
A new commandline parameter `-C` is added to set the settings.
For example, if you want to use the oneliner unparser and the "chain_call" wrapper, you can use
```shell
py -m oneliner <filename> -Cunparser=oneliner -Cexpr_wrapper=chain_call
```
The `--unparser` parameter is deprecated and will be removed in Oneliner-Py 1.3
## 3. Code quality improve
Fix mypy type checker errors. Use generic to simplify code.
Mypy is added to CI.